### PR TITLE
change url from /search to /thoth-search

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 
 This is a React powered web app for displaying Python package metadata and insights using Thoth Advise.
-You can check of the latest build here: [thoth-station.ninja/search](https://thoth-station.ninja/search)
+You can check of the latest build here: [thoth-station.ninja/thoth-search](https://thoth-station.ninja/thoth-search)
 
 ## See a bug?
 Create an issue describing the bug and how to reproduce it. It helps if you include the advisor ID or package name and version with your issue.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "thoth-search",
     "version": "0.1.0",
     "private": true,
-    "homepage": "https://thoth-station.github.io/search",
+    "homepage": "https://thoth-station.github.io/thoth-search",
     "dependencies": {
         "@emotion/react": "^11.4.0",
         "@emotion/styled": "^11.3.0",


### PR DESCRIPTION
## Related Issues and Dependencies
#29 

## This introduces a breaking change
- [ ] Yes
- [X] No

## This Pull Request implements
change url from /search to /thoth-search in package.json and update name in readme

## Description

Cannot have url of gh-pages app be something other than repo name
